### PR TITLE
Fixes issue #3

### DIFF
--- a/lib/decision-tree.js
+++ b/lib/decision-tree.js
@@ -51,7 +51,11 @@ module.exports = (function() {
         var childNode = _.detect(root.vals, function(node) {
           return node.name == sampleVal
         });
-        root = childNode.child;
+        if (childNode){
+          root = childNode.child;
+        } else {
+          root = root.vals[0].child;
+        }
       }
 
       return root.val;


### PR DESCRIPTION
If "most dominate feature" route is taken when building the tree then there is no matched childNode in some circumstances, so instead return the only node remaining (which is the result) instead.